### PR TITLE
fixed naming for shared object from static part

### DIFF
--- a/static/pyArborX_static.cpp.in
+++ b/static/pyArborX_static.cpp.in
@@ -5,8 +5,8 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(pyArborX, m) {
-  m.attr("__name__") = "pyArborX";
+PYBIND11_MODULE(pyArborX_static, m) {
+  m.attr("__name__") = "pyArborX_static";
 
   m.def("printConfig", []() { Kokkos::print_configuration(std::cout); });
 


### PR DESCRIPTION
Apparently I missed renaming the pybind11 module for the static part from `pyArborX` into `pyArborX_static`. With the wrong name python will throw an input error