### PR TITLE
Allow View generation for non-ArborX types

### DIFF
--- a/static/CMakeLists.txt
+++ b/static/CMakeLists.txt
@@ -1,34 +1,43 @@
 project(pyArborX_static LANGUAGES CXX)
 
-#choose modules that should be included in the build
+# Choose modules to be included
 set(pyArborX_STATIC_GEOMETRY_MODULES Point Box Sphere)
 set(pyArborX_STATIC_UTILITY_MODULES Experimental)
 
-# get source files for selected static modules
+# Grab source files for the selected static modules
 foreach(PY_MODULE IN LISTS pyArborX_STATIC_GEOMETRY_MODULES pyArborX_STATIC_UTILITY_MODULES)
   list(APPEND pyArborX_SRC ${PROJECT_SOURCE_DIR}/src/pyArborX_${PY_MODULE}.cpp)
   list(APPEND MODULE_INCLUDES "\n#include \"pyArborX_${PY_MODULE}.hpp\"" )
   list(APPEND MODULE_GENERATORS "\npyArborX::generate${PY_MODULE}Wrapper(m)")
 endforeach()
 
-#generate bindings for views of ArborX types
-set(LAYOUTS LayoutLeft LayoutRight)
-set(MEMORYSPACES Default HostSpace)
+# Generate View bindings
+set(pyArborX_STATIC_VIEW_TYPES ${pyArborX_STATIC_GEOMETRY_MODULES})
+list(TRANSFORM pyArborX_STATIC_VIEW_TYPES PREPEND "ArborX::")
+list(APPEND pyArborX_STATIC_VIEW_TYPES "int") # extra types
+
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/generated_files)
 
-foreach(GEOMETRY IN LISTS pyArborX_STATIC_GEOMETRY_MODULES)
+set(LAYOUTS LayoutLeft LayoutRight)
+set(MEMORYSPACES Default HostSpace)
+foreach(VIEW_BASE_TYPE IN LISTS pyArborX_STATIC_VIEW_TYPES)
   foreach(LAYOUT IN LISTS LAYOUTS)
     foreach(MEMORYSPACE IN LISTS MEMORYSPACES)
-      set(VIEW_NAME "Kokkos_View_ArborX_${GEOMETRY}_1D_${LAYOUT}_${MEMORYSPACE}")
+      string(REPLACE "::" "_" VIEW_BASE_NAME ${VIEW_BASE_TYPE})
+      set(VIEW_NAME "Kokkos_View_${VIEW_BASE_NAME}_1D_${LAYOUT}_${MEMORYSPACE}")
       if (MEMORYSPACE STREQUAL Default)
-        set(VIEW_TYPE "Kokkos::View<ArborX::${GEOMETRY}*,Kokkos::${LAYOUT},Kokkos::${MEMORYSPACE}ExecutionSpace::memory_space>")
+        set(VIEW_TYPE "Kokkos::View<${VIEW_BASE_TYPE}*,Kokkos::${LAYOUT},Kokkos::${MEMORYSPACE}ExecutionSpace::memory_space>")
       else()
-        set(VIEW_TYPE "Kokkos::View<ArborX::${GEOMETRY}*,Kokkos::${LAYOUT},Kokkos::${MEMORYSPACE}>")
+        set(VIEW_TYPE "Kokkos::View<${VIEW_BASE_TYPE}*,Kokkos::${LAYOUT},Kokkos::${MEMORYSPACE}>")
       endif()
-      set(VIEW_BASE_TYPE "ArborX::${GEOMETRY}")
       set(VIEW_INCLUDE "\n#include \"pyArborX_${VIEW_NAME}.hpp\"")
 
       configure_file(include/pyArborX_Views.hpp.in generated_files/pyArborX_${VIEW_NAME}.hpp)
+      if(VIEW_BASE_TYPE MATCHES "^ArborX::")
+        set(INCLUDE_HEADER "${VIEW_BASE_NAME}.hpp")
+      else()
+        set(INCLUDE_HEADER "string")
+      endif()
       configure_file(src/pyArborX_Views.cpp.in generated_files/pyArborX_${VIEW_NAME}.cpp)
       list(APPEND pyArborX_SRC ${PROJECT_BINARY_DIR}/generated_files/pyArborX_${VIEW_NAME}.cpp)
       list(APPEND MODULE_INCLUDES "\n#include \"pyArborX_${VIEW_NAME}.hpp\"" )
@@ -36,7 +45,6 @@ foreach(GEOMETRY IN LISTS pyArborX_STATIC_GEOMETRY_MODULES)
     endforeach()
   endforeach()
 endforeach()
-
 
 string(REPLACE ";" " " MODULE_INCLUDES "${MODULE_INCLUDES}")
 

--- a/static/include/pyArborX_Views.hpp.in
+++ b/static/include/pyArborX_Views.hpp.in
@@ -8,7 +8,7 @@ namespace py = pybind11;
 namespace pyArborX
 {
 
-void generate@VIEW_NAME@Wrapper(py::module & m);
+void generate@VIEW_NAME@Wrapper(py::module &m);
 
 }
 #endif

--- a/static/src/pyArborX_Views.cpp.in
+++ b/static/src/pyArborX_Views.cpp.in
@@ -1,35 +1,44 @@
 #ifndef PYARBORX_@VIEW_NAME@_CPP
 #define PYARBORX_@VIEW_NAME@_CPP
 
+#include <@INCLUDE_HEADER@>
 #include <pybind11/pybind11.h>
-#include <ArborX_@GEOMETRY@.hpp>
+#include <Kokkos_Core.hpp>
 
 @VIEW_INCLUDE@
 
 namespace py = pybind11;
 
-namespace pyArborX{
+namespace pyArborX
+{
 
-void generate@VIEW_NAME@Wrapper(py::module & m) {
-    py::class_<@VIEW_TYPE@>(m,"@VIEW_NAME@")
+void generate@VIEW_NAME@Wrapper(py::module &m)
+{
+  py::class_<@VIEW_TYPE@>(m, "@VIEW_NAME@")
       .def(py::init<>())
-      .def(py::init([](std::string label,size_t size){
-            return new @VIEW_TYPE@{label,size};}))
+      .def(py::init([](std::string label, size_t size) {
+        return new @VIEW_TYPE@{label, size};
+      }))
 
-    .def("size",[](@VIEW_TYPE@& p){return p.size();})
-    .def("__getitem__",
-        [](@VIEW_TYPE@& p,long unsigned int idx){ return p(idx);}
-        )
-    .def("__setitem__",
-        [](@VIEW_TYPE@& p,long unsigned int idx, @VIEW_BASE_TYPE@ val){p(idx)=val;}
-        )
-    .def("cpp_type", [](){return "@VIEW_TYPE@";});
+      .def("size", [](@VIEW_TYPE@ &p) { return p.size(); })
+      .def("__getitem__",
+           [](@VIEW_TYPE@ &p, long unsigned int idx) { return p(idx); })
+      .def("__setitem__", [](@VIEW_TYPE@ &p, long unsigned int idx,
+                             @VIEW_BASE_TYPE@ val) { p(idx) = val; })
+      .def("cpp_type", []() { return "@VIEW_TYPE@"; });
 
+  // binding as member functions to avoid even more overloading problems
+  m.def(
+      "create_mirror_view",
+      [](@VIEW_TYPE@ const &src) { return Kokkos::create_mirror_view(src); },
+      py::arg("src"));
 
-    // binding as member functions to avoid even more overloading problems
-    m.def("create_mirror_view",[](@VIEW_TYPE@ const & src){return Kokkos::create_mirror_view(src);},py::arg("src"));
-
-    m.def("deep_copy",[](@VIEW_TYPE@ const & dest,decltype(create_mirror_view(std::declval<@VIEW_TYPE@>())) const & src){return Kokkos::deep_copy(dest,src);},py::arg("dest"),py::arg("src"));
+  m.def(
+      "deep_copy",
+      [](@VIEW_TYPE@ const &dest,
+         decltype(create_mirror_view(std::declval<@VIEW_TYPE@>()))
+             const &src) { return Kokkos::deep_copy(dest, src); },
+      py::arg("dest"), py::arg("src"));
 }
 } // namespace pyArborX
 #endif


### PR DESCRIPTION
This is useful for `int`, which is a type that ArborX can return offsets and indices in.